### PR TITLE
Converting json content to ps custom object to lookup fullname.

### DIFF
--- a/Private/Get-JenkinsUserInfo.ps1
+++ b/Private/Get-JenkinsUserInfo.ps1
@@ -18,7 +18,7 @@ function Get-JenkinsUserInfo {
         return $userInfo
     } else {
         $response = Invoke-JenkinsRequest -Resource "/user/$UsernameToLookup/api/json" -Username $Username -Password $Password
-        $script:allUserInfo[$UsernameToLookup] = $response.Content
+        $script:allUserInfo[$UsernameToLookup] = $response.Content | ConvertFrom-Json
         return $script:allUserInfo[$UsernameToLookup]
     }
 }

--- a/Tests/Get-JenkinsUserFullName.Tests.ps1
+++ b/Tests/Get-JenkinsUserFullName.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Get-JenkinsUserFullName method' {
             }
         ]
 }
-"@ | ConvertFrom-Json
+"@
 
     $Fullname2 = "praise the sun"
     $UserInfo2 = @"
@@ -40,7 +40,7 @@ Describe 'Get-JenkinsUserFullName method' {
             }
         ]
 }
-"@ | ConvertFrom-Json
+"@
 
     $user1 = $UserInfo1.id
     $user2 = $UserInfo2.id


### PR DESCRIPTION
Lookup of `fullName` failed in `Get-JenkinsUserFullName.ps1` due to the returned value not being a ps object.