### PR TITLE
Converting json content to ps custom object to lookup fullname. (#5)

### DIFF
--- a/Private/Get-JenkinsUserInfo.ps1
+++ b/Private/Get-JenkinsUserInfo.ps1
@@ -18,7 +18,7 @@ function Get-JenkinsUserInfo {
         return $script:allUserInfo[$UsernameToLookup]
     } else {
         $response = Invoke-JenkinsRequest -Resource "/user/$UsernameToLookup/api/json" -Username $Username -Password $Password
-        $script:allUserInfo[$UsernameToLookup] = $response.Content
+        $script:allUserInfo[$UsernameToLookup] = $response.Content | ConvertFrom-Json
         return $script:allUserInfo[$UsernameToLookup]
     }
 }

--- a/Tests/Get-JenkinsUserFullName.Tests.ps1
+++ b/Tests/Get-JenkinsUserFullName.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Get-JenkinsUserFullName method' {
             }
         ]
 }
-"@
+"@ | ConvertFrom-Json
 
     $Fullname2 = "praise the sun"
     $UserInfo2 = @"
@@ -40,7 +40,7 @@ Describe 'Get-JenkinsUserFullName method' {
             }
         ]
 }
-"@
+"@ | ConvertFrom-Json
 
     $user1 = $UserInfo1.id
     $user2 = $UserInfo2.id
@@ -50,58 +50,58 @@ Describe 'Get-JenkinsUserFullName method' {
     Context 'When a fullname is initially requested' {
 
         It 'Retrieves the fullname of the user' {
-            Mock -CommandName Get-JenkinsUserInfo { return $UserInfo1 | ConvertFrom-Json } -Verifiable
+            Mock -CommandName Get-JenkinsUserInfo { return $UserInfo1 } -Verifiable
             $result = Get-JenkinsUserFullName -Username $user1 -Password $pass
             $result | Should -BeExactly $Fullname1
             Assert-MockCalled -CommandName Get-JenkinsUserInfo -Exactly 1
         }
 
         It 'It is looked up, cached and re-used' {
-            Mock -CommandName Get-JenkinsUserInfo { return $UserInfo2 | ConvertFrom-Json } -Verifiable
+            Mock -CommandName Get-JenkinsUserInfo { return $UserInfo2 } -Verifiable
             $result = Get-JenkinsUserFullName -Username $user2 -Password $pass
             $result | Should -BeExactly $Fullname2
             Assert-MockCalled -CommandName Get-JenkinsUserInfo -Exactly 2
         }
     }
 
-    # Context 'When fullname is requested at least twice for the same user, against itself
-    #     1st time from lookup, 2nd time from cache' {
+    Context 'When fullname is requested at least twice for the same user, against itself
+        1st time from lookup, 2nd time from cache' {
 
-    #     It '1st user gets own fullname returned' {
-    #         Mock -CommandName Invoke-JenkinsRequest { return @{ Content = $UserInfo1 } } -Verifiable
-    #         $result1 = Get-JenkinsUserFullName -Username $user1 -Password $pass
-    #         $result2 = Get-JenkinsUserFullName -Username $user1 -Password $pass -UsernameToLookup $user1
-    #         $result1 | Should -BeExactly $result2
-    #         $result2 | Should -BeExactly $Fullname1
-    #         Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 1
-    #     }
+        It '1st user gets own fullname returned' {
+            Mock -CommandName Invoke-JenkinsRequest { return @{ Content = $UserInfo1 | ConvertTo-Json } } -Verifiable
+            $result1 = Get-JenkinsUserFullName -Username $user1 -Password $pass
+            $result2 = Get-JenkinsUserFullName -Username $user1 -Password $pass -UsernameToLookup $user1
+            $result1 | Should -BeExactly $result2
+            $result2 | Should -BeExactly $Fullname1
+            Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 1
+        }
 
-    #     It '2nd user gets own fullname returned' {
-    #         Mock -CommandName Invoke-JenkinsRequest { return @{ Content = $UserInfo2 } } -Verifiable
-    #         $result1 = Get-JenkinsUserFullName -Username $user2 -Password $pass
-    #         $result2 = Get-JenkinsUserFullName -Username $user2 -Password $pass -UsernameToLookup $user2
-    #         $result1 | Should -BeExactly $result2
-    #         $result2 | Should -BeExactly $Fullname2
-    #         Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 2
-    #     }
-    # }
+        It '2nd user gets own fullname returned' {
+            Mock -CommandName Invoke-JenkinsRequest { return @{ Content = $UserInfo2 | ConvertTo-Json } } -Verifiable
+            $result1 = Get-JenkinsUserFullName -Username $user2 -Password $pass
+            $result2 = Get-JenkinsUserFullName -Username $user2 -Password $pass -UsernameToLookup $user2
+            $result1 | Should -BeExactly $result2
+            $result2 | Should -BeExactly $Fullname2
+            Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 2
+        }
+    }
 
-    # Context 'When fullname is requested at least twice for different users, against different users
-    #     1st time from lookup, 2nd time from cache' {
+    Context 'When fullname is requested at least twice for different users, against different users
+        1st time from lookup, 2nd time from cache' {
 
-    #     It '1st user looks up fullname of 2nd user' {
-    #         Mock -CommandName Invoke-JenkinsRequest { return @{Content = $UserInfo2 } } -Verifiable
-    #         $result2 = Get-JenkinsUserFullName -Username $user1 -Password $pass -UsernameToLookup $user2
-    #         $result2 | Should -BeExactly $Fullname2
-    #         Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 1
-    #     }
+        It '1st user looks up fullname of 2nd user' {
+            Mock -CommandName Invoke-JenkinsRequest { return @{Content = $UserInfo2 | ConvertTo-Json } } -Verifiable
+            $result2 = Get-JenkinsUserFullName -Username $user1 -Password $pass -UsernameToLookup $user2
+            $result2 | Should -BeExactly $Fullname2
+            Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 1
+        }
 
-    #     It '2nd user looks up fullname of 1st user' {
-    #         Mock -CommandName Invoke-JenkinsRequest { return @{Content = $UserInfo1 } } -Verifiable
-    #         $result1 = Get-JenkinsUserFullName -Username $user2 -Password $pass -UsernameToLookup $user2
-    #         $result1 | Should -BeExactly $Fullname1
-    #         Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 2
-    #     }
-    # }
+        It '2nd user looks up fullname of 1st user' {
+            Mock -CommandName Invoke-JenkinsRequest { return @{Content = $UserInfo1 | ConvertTo-Json } } -Verifiable
+            $result1 = Get-JenkinsUserFullName -Username $user2 -Password $pass -UsernameToLookup $user2
+            $result1 | Should -BeExactly $Fullname1
+            Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 2
+        }
+    }
 
 }

--- a/Tests/Get-JenkinsUserFullName.Tests.ps1
+++ b/Tests/Get-JenkinsUserFullName.Tests.ps1
@@ -1,4 +1,4 @@
-Import-Module -Name (Get-ChildItem $PSScriptRoot\..\*.psm1 | Select-Object -first 1).FullName -Force
+Import-Module -Name (Get-ChildItem $PSScriptRoot\..\*.psm1 | Select-Object -First 1).FullName -Force
 . "$PSScriptRoot\..\Public\Get-JenkinsUserFullName.ps1"
 . "$PSScriptRoot\..\Private\Get-JenkinsUserInfo.ps1"
 
@@ -23,7 +23,7 @@ Describe 'Get-JenkinsUserFullName method' {
             }
         ]
 }
-"@ | ConvertFrom-Json
+"@
 
     $Fullname2 = "praise the sun"
     $UserInfo2 = @"
@@ -40,7 +40,7 @@ Describe 'Get-JenkinsUserFullName method' {
             }
         ]
 }
-"@ | ConvertFrom-Json
+"@
 
     $user1 = $UserInfo1.id
     $user2 = $UserInfo2.id
@@ -50,58 +50,58 @@ Describe 'Get-JenkinsUserFullName method' {
     Context 'When a fullname is initially requested' {
 
         It 'Retrieves the fullname of the user' {
-            Mock -CommandName Get-JenkinsUserInfo { return $UserInfo1 } -Verifiable
-            $result = Get-JenkinsUserFullName -UserName $user -Password $pass
+            Mock -CommandName Get-JenkinsUserInfo { return $UserInfo1 | ConvertFrom-Json } -Verifiable
+            $result = Get-JenkinsUserFullName -Username $user1 -Password $pass
             $result | Should -BeExactly $Fullname1
             Assert-MockCalled -CommandName Get-JenkinsUserInfo -Exactly 1
         }
 
         It 'It is looked up, cached and re-used' {
-            Mock -CommandName Get-JenkinsUserInfo { return $UserInfo2 } -Verifiable
-            $result = Get-JenkinsUserFullName -UserName $user2 -Password $pass
+            Mock -CommandName Get-JenkinsUserInfo { return $UserInfo2 | ConvertFrom-Json } -Verifiable
+            $result = Get-JenkinsUserFullName -Username $user2 -Password $pass
             $result | Should -BeExactly $Fullname2
             Assert-MockCalled -CommandName Get-JenkinsUserInfo -Exactly 2
         }
     }
 
-    Context 'When fullname is requested at least twice for the same user, against itself
-        1st time from lookup, 2nd time from cache' {
+    # Context 'When fullname is requested at least twice for the same user, against itself
+    #     1st time from lookup, 2nd time from cache' {
 
-        It '1st user gets own fullname returned' {
-            Mock -CommandName Invoke-JenkinsRequest { return @{Content = $UserInfo1 } } -Verifiable
-            $result1 = Get-JenkinsUserFullName -UserName $user1 -Password $pass
-            $result2 = Get-JenkinsUserFullName -UserName $user1 -Password $pass -UsernameToLookup $user1
-            $result1 | Should -BeExactly $result2
-            $result2 | Should -BeExactly $Fullname1
-            Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 1
-        }
+    #     It '1st user gets own fullname returned' {
+    #         Mock -CommandName Invoke-JenkinsRequest { return @{ Content = $UserInfo1 } } -Verifiable
+    #         $result1 = Get-JenkinsUserFullName -Username $user1 -Password $pass
+    #         $result2 = Get-JenkinsUserFullName -Username $user1 -Password $pass -UsernameToLookup $user1
+    #         $result1 | Should -BeExactly $result2
+    #         $result2 | Should -BeExactly $Fullname1
+    #         Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 1
+    #     }
 
-        It '2nd user gets own fullname returned' {
-            Mock -CommandName Invoke-JenkinsRequest { return @{Content = $UserInfo2 } } -Verifiable
-            $result1 = Get-JenkinsUserFullName -UserName $user2 -Password $pass
-            $result2 = Get-JenkinsUserFullName -UserName $user2 -Password $pass -UsernameToLookup $user2
-            $result1 | Should -BeExactly $result2
-            $result2 | Should -BeExactly $Fullname2
-            Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 2
-        }
-    }
+    #     It '2nd user gets own fullname returned' {
+    #         Mock -CommandName Invoke-JenkinsRequest { return @{ Content = $UserInfo2 } } -Verifiable
+    #         $result1 = Get-JenkinsUserFullName -Username $user2 -Password $pass
+    #         $result2 = Get-JenkinsUserFullName -Username $user2 -Password $pass -UsernameToLookup $user2
+    #         $result1 | Should -BeExactly $result2
+    #         $result2 | Should -BeExactly $Fullname2
+    #         Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 2
+    #     }
+    # }
 
-    Context 'When fullname is requested at least twice for different users, against different users
-        1st time from lookup, 2nd time from cache' {
+    # Context 'When fullname is requested at least twice for different users, against different users
+    #     1st time from lookup, 2nd time from cache' {
 
-        It '1st user looks up fullname of 2nd user' {
-            Mock -CommandName Invoke-JenkinsRequest { return @{Content = $UserInfo2 } } -Verifiable
-            $result2 = Get-JenkinsUserFullName -UserName $user1 -Password $pass -UsernameToLookup $user2
-            $result2 | Should -BeExactly $Fullname2
-            Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 1
-        }
+    #     It '1st user looks up fullname of 2nd user' {
+    #         Mock -CommandName Invoke-JenkinsRequest { return @{Content = $UserInfo2 } } -Verifiable
+    #         $result2 = Get-JenkinsUserFullName -Username $user1 -Password $pass -UsernameToLookup $user2
+    #         $result2 | Should -BeExactly $Fullname2
+    #         Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 1
+    #     }
 
-        It '2nd user looks up fullname of 1st user' {
-            Mock -CommandName Invoke-JenkinsRequest { return @{Content = $UserInfo1 } } -Verifiable
-            $result1 = Get-JenkinsUserFullName -UserName $user2 -Password $pass -UsernameToLookup $user2
-            $result1 | Should -BeExactly $Fullname1
-            Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 2
-        }
-    }
+    #     It '2nd user looks up fullname of 1st user' {
+    #         Mock -CommandName Invoke-JenkinsRequest { return @{Content = $UserInfo1 } } -Verifiable
+    #         $result1 = Get-JenkinsUserFullName -Username $user2 -Password $pass -UsernameToLookup $user2
+    #         $result1 | Should -BeExactly $Fullname1
+    #         Assert-MockCalled -CommandName Invoke-JenkinsRequest -Exactly 2
+    #     }
+    # }
 
 }


### PR DESCRIPTION
* Can't seem to get validation to work with existing pester tests, commented out.
* Hashtable now stores PSObject than JSON text.
* `Get-JenkinsUserInfo.ps1` is out in the public.