### PR TITLE
Require Powershell Core v6

### DIFF
--- a/Private/ConvertTo-BasicAuth.ps1
+++ b/Private/ConvertTo-BasicAuth.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Core -Version 6
+
 function ConvertTo-BasicAuth {
     param (
         [String] $Username,

--- a/Private/Get-CrumbHeader.ps1
+++ b/Private/Get-CrumbHeader.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Core -Version 6
+
 function Get-CrumbHeader {
     [CmdletBinding()]
     param (

--- a/Private/Get-JenkinsRequestHeaders.ps1
+++ b/Private/Get-JenkinsRequestHeaders.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Core -Version 6
+
 function Get-JenkinsRequestHeaders {
     param (
         [Parameter(Mandatory)]

--- a/Private/Get-JenkinsUserInfo.ps1
+++ b/Private/Get-JenkinsUserInfo.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Core -Version 6
+
 function Get-JenkinsUserInfo {
     [CmdletBinding()]
     param (

--- a/Private/Get-Params.ps1
+++ b/Private/Get-Params.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Core -Version 6
+
 function Get-Params
 {
     param (

--- a/Public/Get-JenkinsUserFullName.ps1
+++ b/Public/Get-JenkinsUserFullName.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Core -Version 6
+
 . "$PSScriptRoot\..\Private\Get-JenkinsUserInfo.ps1"
 
 function Get-JenkinsUserFullName {

--- a/Public/Initialize-Jenkins.ps1
+++ b/Public/Initialize-Jenkins.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Core -Version 6
+
 function Initialize-Jenkins {
     [CmdletBinding()]
     param (

--- a/Public/Invoke-Jenkins.ps1
+++ b/Public/Invoke-Jenkins.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Core -Version 6
+
 function Invoke-Jenkins {
     [CmdletBinding()]
     param (

--- a/Public/Invoke-JenkinsForm.ps1
+++ b/Public/Invoke-JenkinsForm.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Core -Version 6
+
 function Invoke-JenkinsForm {
     [CmdletBinding()]
     param (

--- a/Public/Invoke-JenkinsRequest.ps1
+++ b/Public/Invoke-JenkinsRequest.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Core -Version 6
+
 function Invoke-JenkinsRequest {
     [CmdletBinding()]
     param (

--- a/Public/New-JenkinsJob.ps1
+++ b/Public/New-JenkinsJob.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Core -Version 6
+
 function New-JenkinsJob {
     [CmdletBinding()]
     param (

--- a/Public/Remove-JenkinsJob.ps1
+++ b/Public/Remove-JenkinsJob.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Core -Version 6
+
 function Remove-JenkinsJob {
     [CmdletBinding()]
     param (

--- a/Tests/Get-CrumbHeader.Tests.ps1
+++ b/Tests/Get-CrumbHeader.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Get-CrumbHeader method' {
 
             $crumbHeader = Get-CrumbHeader -UserName $user -Password $pass
             Assert-MockCalled -CommandName Invoke-RestMethod -Exactly 1
-            $crumbHeader | Should -BeExactly "requestfield=headerdata"            
+            $crumbHeader | Should -BeExactly "requestfield=headerdata"
         }
     }
 


### PR DESCRIPTION
Bump requirements to Powershell Core 6, now enforced in the scripts and modules.