### PR TITLE
Use session to work with new CSRF check in 2.176.3+

### DIFF
--- a/Private/Get-CrumbHeader.ps1
+++ b/Private/Get-CrumbHeader.ps1
@@ -13,13 +13,18 @@ function Get-CrumbHeader {
         $script:crumbsByUser = [hashtable]::new()
     }
 
+    if (!$script:sessionByUser) {
+        $script:sessionByUser = [hashtable]::new()
+    }
+
     if ($crumbHeader = $crumbsByUser[$Username]) {
         return $crumbHeader
     } else {
         $uri = "$script:jenkinsUrl/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,`":`",//crumb)"
         $basicAuthCreds = ConvertTo-BasicAuth -Username $Username -Password $Password
         $requestHeaders = @{ Authorization = "Basic $basicAuthCreds" }
-        $crumbHeader = Invoke-RestMethod -Uri $uri -Method "Get" -Headers $requestHeaders -UseBasicParsing
+        $crumbHeader = Invoke-RestMethod -Uri $uri -Method "Get" -Headers $requestHeaders -UseBasicParsing -SessionVariable 'Session'
+        $script:sessionByUser[$Username] = $Session
         $script:crumbsByUser[$Username] = $crumbHeader.Replace(":", "=")
         return $crumbsByUser[$Username]
     }

--- a/Public/Invoke-Jenkins.ps1
+++ b/Public/Invoke-Jenkins.ps1
@@ -31,26 +31,27 @@ function Invoke-Jenkins {
     Write-Debug "Body: $Body"
     Write-Debug "Query: $Query"
 
+    $req = @{
+        Uri = $request.Uri
+        Headers = $headers
+        Method = $Method
+        UseBasicParsing = $true
+        TimeOutSec = 30
+        ErrorAction = "SilentlyContinue"
+        MaximumRedirection = $MaximumRedirectionCount
+    }
+    if($null -ne $Form){
+        $req.Form = $Form
+    }
+    else {
+        $req.Body = $Body
+        $req.ContentType = $ContentType
+    }
+
     while ($attempts -lt $MaximumAttempts) {
 
         try {
             $attempts += 1
-            $req = @{
-                Uri = $request.Uri
-                Headers = $headers
-                Method = $Method
-                UseBasicParsing = $true
-                TimeOutSec = 30
-                ErrorAction = "SilentlyContinue"
-                MaximumRedirection = $MaximumRedirectionCount
-            }
-            if($null -ne $Form){
-                $req.Form = $Form
-            }
-            else {
-                $req.Body = $Body
-                $req.ContentType = $ContentType
-            }
             $response = Invoke-WebRequest @req
             Write-Debug "Response for Invoke-Jenkins: StatusCode : $($response.StatusCode), Headers: $($response.Headers), Content: $($response.Content)"
             return $response

--- a/Public/Invoke-Jenkins.ps1
+++ b/Public/Invoke-Jenkins.ps1
@@ -39,6 +39,7 @@ function Invoke-Jenkins {
         TimeOutSec = 30
         ErrorAction = "SilentlyContinue"
         MaximumRedirection = $MaximumRedirectionCount
+        WebSession = $script:sessionByUser[$Username]
     }
     if($null -ne $Form){
         $req.Form = $Form

--- a/Public/Invoke-Jenkins.ps1
+++ b/Public/Invoke-Jenkins.ps1
@@ -35,27 +35,23 @@ function Invoke-Jenkins {
 
         try {
             $attempts += 1
+            $req = @{
+                Uri = $request.Uri
+                Headers = $headers
+                Method = $Method
+                UseBasicParsing = $true
+                TimeOutSec = 30
+                ErrorAction = "SilentlyContinue"
+                MaximumRedirection = $MaximumRedirectionCount
+            }
             if($null -ne $Form){
-                $response = Invoke-WebRequest -Uri $Request.Uri `
-                -Headers $headers `
-                -Method $Method `
-                -Form $Form `
-                -UseBasicParsing `
-                -TimeoutSec 30 `
-                -ErrorAction SilentlyContinue `
-                -MaximumRedirection $MaximumRedirectionCount
+                $req.Form = $Form
             }
             else {
-                $response = Invoke-WebRequest -Uri $Request.Uri `
-                -Headers $headers `
-                -Method $Method `
-                -Body $body `
-                -ContentType $ContentType `
-                -UseBasicParsing `
-                -TimeoutSec 30 `
-                -ErrorAction SilentlyContinue `
-                -MaximumRedirection $MaximumRedirectionCount
+                $req.Body = $Body
+                $req.ContentType = $ContentType
             }
+            $response = Invoke-WebRequest @req
             Write-Debug "Response for Invoke-Jenkins: StatusCode : $($response.StatusCode), Headers: $($response.Headers), Content: $($response.Content)"
             return $response
         } catch [System.Net.Http.HttpRequestException] {
@@ -75,5 +71,3 @@ function Invoke-Jenkins {
         }
     }
 }
-
-


### PR DESCRIPTION
After 2.176.3 security advisory it is suggested to reuse the session to further validate against CSRF.

See https://jenkins.io/security/advisory/2019-08-28/